### PR TITLE
Update version to HEAD / 1.3.0.pre, build against Arrow 0.6.0 final

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,5 +1,5 @@
 set PARQUET_BUILD_TOOLCHAIN=%LIBRARY_PREFIX%
-set PARQUET_ARROW_VERSION=3a84653a3aa00f36f6312a11e58d1daf41dedcee
+set PARQUET_ARROW_VERSION=b17333482ea1da3728538bc912b1053ba70ed2e7
 
 REM Set short build path to not overcome max obj files path length of 150 characters on Windows
 mkdir C:\bld\build

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,7 @@ set -x
 export PARQUET_BUILD_TOOLCHAIN=$PREFIX
 
 # Use PARQUET_ARROW_VERSION if it's already defined by the caller
-export PARQUET_ARROW_VERSION=${PARQUET_ARROW_VERSION:=3a84653a3aa00f36f6312a11e58d1daf41dedcee}
+export PARQUET_ARROW_VERSION=${PARQUET_ARROW_VERSION:=b17333482ea1da3728538bc912b1053ba70ed2e7}
 
 mkdir build-dir
 cd build-dir

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.2.0" %}
-{% set commit = "e9a8bfef49d376d35cf0ecedd9967f3dab350259" %}
-{% set sha256sum = "b26b55872e1a08aa8131d4d90cb13d733e25733ade7d3e1495c3c05e1a5c9f94" %}
+{% set version = "1.3.0.pre" %}
+{% set commit = "f8401b15ab83823470a0c404364be73270398d83" %}
+{% set sha256sum = "01827f479280dcc1dffdae43d2746ce353eb90b33783c3512ec1611d844076fc" %}
 
 # NOTE(wesm): When updating the build, please remember also to update the
 # pinned Arrow version. We are letting parquet-cpp build its own Apache Arrow
@@ -32,7 +32,7 @@ requirements:
     - python            # [win]
 
   run:
-    - arrow-cpp 0.5.*
+    - arrow-cpp 0.6.*
 
 test:
   requires:


### PR DESCRIPTION
see also https://github.com/conda-forge/arrow-cpp-feedstock/pull/36